### PR TITLE
fix: populate grade field from explainGrade when grade is empty

### DIFF
--- a/utils/parseHadithInfo.js
+++ b/utils/parseHadithInfo.js
@@ -66,6 +66,12 @@ function parseHadithInfo(infoElement) {
   const sharhId = sharhElement?.getAttribute('xplain');
   result.sharhId = sharhId && sharhId !== '0' ? sharhId : null;
 
+  // If grade is empty but explainGrade has a value, use explainGrade for grade
+  // This is because dorar.net only shows "خلاصة حكم المحدث" (explainGrade) in search results
+  if (!result.grade && result.explainGrade) {
+    result.grade = result.explainGrade;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
# Pull Request: Fix Empty Grade Field in Hadith Search Results

## Description

This PR fixes an issue where the `grade` field was always empty in the `/v1/site/hadith/search` API response, even when hadith grading information was available.

## Problem

The API was attempting to extract both `درجة الحديث` (grade) and `خلاصة حكم المحدث` (explainGrade) fields from the dorar.net HTML. However, in search results, dorar.net only displays `خلاصة حكم المحدث` (explainGrade), causing the `grade` field to always remain empty.

## Solution

Updated parseHadithInfo.js to populate the `grade` field with the value from `explainGrade` when `grade` is empty. This ensures that:
- Clients always receive meaningful grading information in the `grade` field
- The `explainGrade` field remains unchanged for backward compatibility
- Both fields contain the same value when only one is available in the source HTML

## Changes

- Modified parseHadithInfo.js to add fallback logic (lines 70-73)

## Testing

Tested with the following request:
```
GET /v1/site/hadith/search?value=وجعل%20يشير%20بيده
```

**Before:**
```json
{
  "grade": "",
  "explainGrade": "[صحيح]"
}
```

**After:**
```json
{
  "grade": "[صحيح]",
  "explainGrade": "[صحيح]"
}
```

All three hadiths in the test response now correctly populate the `grade` field:
- ✅ `"[صحيح]"` (البخاري)
- ✅ `"حسن"` (الألباني)
- ✅ `"أبو عبيدة لم يسمع من أبيه‏ [ابن مسعود] ‏"` (الهيثمي)

## Backward Compatibility

This change is fully backward compatible. Both `grade` and `explainGrade` fields remain in the API response, maintaining existing client functionality.