### PR TITLE
fix(swagger): default OpenAPI server to /v1 and keep localhost as sec…

### DIFF
--- a/api-docs/openapi.yaml
+++ b/api-docs/openapi.yaml
@@ -5,6 +5,7 @@ info:
   description: API for searching and retrieving hadith from Dorar.net
 
 servers:
+  - url: /v1
   - url: http://localhost:5000/v1
 
 paths:


### PR DESCRIPTION
## PR Title
Fix Swagger UI server URL in production (default to same-origin `/v1`)

## Summary
This PR fixes Swagger UI requests failing in production due to a hardcoded localhost server URL in `api-docs/openapi.yaml`.

Previously, Swagger defaulted to:
- `http://localhost:5000/v1`

Now it defaults to:
- `/v1` (same-origin, works in deployed environments)

Local development support is preserved by keeping:
- `http://localhost:5000/v1` as a secondary server option.

## Changes
- Updated `api-docs/openapi.yaml`:
  - Added `/v1` as the first server entry
  - Kept `http://localhost:5000/v1` as the second entry

## Why
In production, Swagger UI runs in the browser. If the OpenAPI server points to localhost, browser requests target the user's machine, causing `Failed to fetch` errors.

Using `/v1` makes requests use the same host/protocol as `/api-docs`, which is correct for deployment.

## Validation
- Opened Swagger UI at `/api-docs`
- Confirmed server dropdown includes:
  - `/v1` (default)
  - `http://localhost:5000/v1`
- Confirmed "Try it out" requests now target deployed origin + `/v1/...` (not localhost)

## Impact
- No runtime API route changes
- No controller/business logic changes
- Documentation/runtime request target behavior in Swagger UI is corrected
